### PR TITLE
修改错误-连线题表单的js文件

### DIFF
--- a/app/assets/javascripts/question_bank/question.js
+++ b/app/assets/javascripts/question_bank/question.js
@@ -17,5 +17,6 @@ jQuery(document).ready(function(){
     if (count>1){
       jQuery(this).closest('.page-new-question-mapping').find(".item:last a").removeClass('hidden')
     }
+    jQuery(this).closest('.page-new-question-mapping').find(".item:last input").val('')
    })
  })


### PR DESCRIPTION
bug：
修改前当“连接选项”文本框里有输入的文字时候，点击“添加一组选项”时，这些文字附带在新加的dom文本框里。
处理方法：
在js文件里“添加一组选项”的按钮点击事件的末尾添加代码，能清空新加dom的input内的文字。